### PR TITLE
fix: import HttpError for booking creation

### DIFF
--- a/packages/features/bookings/lib/handleNewBooking/createBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking/createBooking.ts
@@ -3,6 +3,7 @@ import type { z } from "zod";
 
 import type { routingFormResponseInDbSchema } from "@calcom/app-store/routing-forms/zod";
 import dayjs from "@calcom/dayjs";
+import { HttpError } from "@calcom/lib/http-error";
 import { isPrismaObjOrUndefined } from "@calcom/lib/isPrismaObj";
 import { withReporting } from "@calcom/lib/sentryWrapper";
 import prisma from "@calcom/prisma";


### PR DESCRIPTION
## Summary
- import HttpError in the booking creation helper so runtime references resolve
- unblock /api/book/event by ensuring HttpError is available during booking persistence

## Testing
- yarn lint --filter=@calcom/features

------
https://chatgpt.com/codex/tasks/task_e_68cd3c2364408320bc2dd23d6bfb2f09